### PR TITLE
Fix dark mode initialization before body loads

### DIFF
--- a/improved-website-v14/admin-dashboard.html
+++ b/improved-website-v14/admin-dashboard.html
@@ -42,12 +42,19 @@
     </style>
     <!-- Apply dark mode before page renders -->
     <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body?.classList.add('dark-mode');
-            }
-        } catch (e) {}
+        (function() {
+            try {
+                if (localStorage.getItem('darkMode') === 'true') {
+                    document.documentElement.classList.add('dark-mode');
+                    const applyBodyClass = () => document.body.classList.add('dark-mode');
+                    if (document.body) {
+                        applyBodyClass();
+                    } else {
+                        document.addEventListener('DOMContentLoaded', applyBodyClass);
+                    }
+                }
+            } catch (e) {}
+        })();
     </script>
 </head>
 <body class="bg-gray-50 min-h-screen flex flex-col">

--- a/improved-website-v14/admin-login.html
+++ b/improved-website-v14/admin-login.html
@@ -40,12 +40,19 @@
     </style>
     <!-- Apply dark mode before page renders -->
     <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body.classList.add('dark-mode');
-            }
-        } catch (e) {}
+        (function() {
+            try {
+                if (localStorage.getItem('darkMode') === 'true') {
+                    document.documentElement.classList.add('dark-mode');
+                    const applyBodyClass = () => document.body.classList.add('dark-mode');
+                    if (document.body) {
+                        applyBodyClass();
+                    } else {
+                        document.addEventListener('DOMContentLoaded', applyBodyClass);
+                    }
+                }
+            } catch (e) {}
+        })();
     </script>
 </head>
 <body class="bg-gray-50 min-h-screen flex flex-col">

--- a/improved-website-v14/challenges.html
+++ b/improved-website-v14/challenges.html
@@ -59,12 +59,19 @@
 
     <!-- Apply dark mode class early before page renders to prevent flash of unstyled content -->
     <script>
-      try {
-        if (localStorage.getItem('darkMode') === 'true') {
-          document.documentElement.classList.add('dark-mode');
-          document.body.classList.add('dark-mode');
-        }
-      } catch (e) {}
+        (function() {
+            try {
+                if (localStorage.getItem('darkMode') === 'true') {
+                    document.documentElement.classList.add('dark-mode');
+                    const applyBodyClass = () => document.body.classList.add('dark-mode');
+                    if (document.body) {
+                        applyBodyClass();
+                    } else {
+                        document.addEventListener('DOMContentLoaded', applyBodyClass);
+                    }
+                }
+            } catch (e) {}
+        })();
     </script>
 </head>
 <body class="bg-gray-50">

--- a/improved-website-v14/community.html
+++ b/improved-website-v14/community.html
@@ -41,12 +41,19 @@
     </style>
     <!-- Apply dark mode class early before page renders to prevent flash -->
     <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body.classList.add('dark-mode');
-            }
-        } catch (e) {}
+        (function() {
+            try {
+                if (localStorage.getItem('darkMode') === 'true') {
+                    document.documentElement.classList.add('dark-mode');
+                    const applyBodyClass = () => document.body.classList.add('dark-mode');
+                    if (document.body) {
+                        applyBodyClass();
+                    } else {
+                        document.addEventListener('DOMContentLoaded', applyBodyClass);
+                    }
+                }
+            } catch (e) {}
+        })();
     </script>
 </head>
 <body class="bg-gray-50">

--- a/improved-website-v14/health-assessment.html
+++ b/improved-website-v14/health-assessment.html
@@ -48,11 +48,18 @@
     </style>
     <!-- Early dark-mode application -->
     <script>
-        // Immediately apply dark mode if user preference is stored
-        if (localStorage.getItem('darkMode') === 'true') {
-            document.documentElement.classList.add('dark-mode');
-            document.body.classList.add('dark-mode');
-        }
+        (function() {
+            // Immediately apply dark mode if user preference is stored
+            if (localStorage.getItem('darkMode') === 'true') {
+                document.documentElement.classList.add('dark-mode');
+                const applyBodyClass = () => document.body.classList.add('dark-mode');
+                if (document.body) {
+                    applyBodyClass();
+                } else {
+                    document.addEventListener('DOMContentLoaded', applyBodyClass);
+                }
+            }
+        })();
     </script>
 </head>
 <body class="bg-gray-50 transition-all duration-500">

--- a/improved-website-v14/home.html
+++ b/improved-website-v14/home.html
@@ -18,12 +18,19 @@
       color: #e2e8f0 !important;
     }
   </style>
-  <script>
-    if (localStorage.getItem('darkMode') === 'true') {
-      document.documentElement.classList.add('dark-mode');
-      document.body.classList.add('dark-mode');
-    }
-  </script>
+    <script>
+      (function() {
+        if (localStorage.getItem('darkMode') === 'true') {
+          document.documentElement.classList.add('dark-mode');
+          const applyBodyClass = () => document.body.classList.add('dark-mode');
+          if (document.body) {
+            applyBodyClass();
+          } else {
+            document.addEventListener('DOMContentLoaded', applyBodyClass);
+          }
+        }
+      })();
+    </script>
 </head>
 <body class="bg-gray-50 transition-all duration-500">
   <!-- Navigation Bar -->

--- a/improved-website-v14/index.html
+++ b/improved-website-v14/index.html
@@ -46,12 +46,19 @@
 
     <!-- Apply dark mode class early before page renders to prevent flash -->
     <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body.classList.add('dark-mode');
-            }
-        } catch (e) {}
+        (function() {
+            try {
+                if (localStorage.getItem('darkMode') === 'true') {
+                    document.documentElement.classList.add('dark-mode');
+                    const applyBodyClass = () => document.body.classList.add('dark-mode');
+                    if (document.body) {
+                        applyBodyClass();
+                    } else {
+                        document.addEventListener('DOMContentLoaded', applyBodyClass);
+                    }
+                }
+            } catch (e) {}
+        })();
     </script>
 </head>
 <body class="text-gray-700 antialiased">

--- a/improved-website-v14/progress.html
+++ b/improved-website-v14/progress.html
@@ -46,12 +46,19 @@
 
     <!-- Apply dark mode class early before page renders to prevent flash -->
     <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body.classList.add('dark-mode');
-            }
-        } catch (e) {}
+        (function() {
+            try {
+                if (localStorage.getItem('darkMode') === 'true') {
+                    document.documentElement.classList.add('dark-mode');
+                    const applyBodyClass = () => document.body.classList.add('dark-mode');
+                    if (document.body) {
+                        applyBodyClass();
+                    } else {
+                        document.addEventListener('DOMContentLoaded', applyBodyClass);
+                    }
+                }
+            } catch (e) {}
+        })();
     </script>
 </head>
 <body class="bg-gray-50">

--- a/improved-website-v14/redeem.html
+++ b/improved-website-v14/redeem.html
@@ -53,12 +53,19 @@
     </style>
     <!-- Apply dark mode class early before page renders to prevent flash -->
     <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body.classList.add('dark-mode');
-            }
-        } catch (e) {}
+        (function() {
+            try {
+                if (localStorage.getItem('darkMode') === 'true') {
+                    document.documentElement.classList.add('dark-mode');
+                    const applyBodyClass = () => document.body.classList.add('dark-mode');
+                    if (document.body) {
+                        applyBodyClass();
+                    } else {
+                        document.addEventListener('DOMContentLoaded', applyBodyClass);
+                    }
+                }
+            } catch (e) {}
+        })();
     </script>
 </head>
 <body class="bg-gray-50">

--- a/improved-website-v14/resources.html
+++ b/improved-website-v14/resources.html
@@ -54,12 +54,19 @@
     </style>
     <!-- Apply dark mode class early before page renders to prevent flash -->
     <script>
-        try {
-            if (localStorage.getItem('darkMode') === 'true') {
-                document.documentElement.classList.add('dark-mode');
-                document.body.classList.add('dark-mode');
-            }
-        } catch (e) {}
+        (function() {
+            try {
+                if (localStorage.getItem('darkMode') === 'true') {
+                    document.documentElement.classList.add('dark-mode');
+                    const applyBodyClass = () => document.body.classList.add('dark-mode');
+                    if (document.body) {
+                        applyBodyClass();
+                    } else {
+                        document.addEventListener('DOMContentLoaded', applyBodyClass);
+                    }
+                }
+            } catch (e) {}
+        })();
     </script>
 </head>
 <body class="bg-gray-50">


### PR DESCRIPTION
## Summary
- avoid runtime errors when applying dark mode before `<body>` exists
- use a helper that waits for `DOMContentLoaded` if needed

## Testing
- `npx htmlhint improved-website-v14/index.html improved-website-v14/home.html improved-website-v14/admin-login.html improved-website-v14/admin-dashboard.html improved-website-v14/health-assessment.html improved-website-v14/community.html improved-website-v14/redeem.html improved-website-v14/resources.html improved-website-v14/progress.html improved-website-v14/challenges.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893a6dc14248320960d840119b812f1