### PR TITLE
Implement server-side login and remove client auth storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/improved-website-v14/login.html
+++ b/improved-website-v14/login.html
@@ -168,25 +168,30 @@
         });
 
         // Handle login submission
-        loginForm.addEventListener('submit', (e) => {
+        loginForm.addEventListener('submit', async (e) => {
             e.preventDefault();
-            const emailInput = loginForm.querySelector('input[type="email"]');
-            const emailVal = emailInput.value.trim();
-            let userName = 'User';
-            if (emailVal.includes('@')) {
-                userName = emailVal.split('@')[0];
+            const email = loginForm.querySelector('input[type="email"]').value.trim();
+            const password = loginForm.querySelector('input[type="password"]').value;
+            try {
+                const response = await fetch('/api/login', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ email, password })
+                });
+                if (!response.ok) {
+                    throw new Error('Invalid credentials');
+                }
+                const data = await response.json();
+                if (data.redirect) {
+                    window.location.href = data.redirect;
+                }
+            } catch (err) {
+                alert(err.message);
             }
-            localStorage.setItem('ahelpUserName', userName);
-            // Redirect to dashboard
-            window.location.href = 'dashboard.html';
         });
         // Handle sign up submission
         signupForm.addEventListener('submit', (e) => {
             e.preventDefault();
-            const firstName = signupForm.querySelector('input[placeholder="Jane"]').value.trim();
-            if (firstName) {
-                localStorage.setItem('ahelpUserName', firstName);
-            }
             window.location.href = 'dashboard.html';
         });
     </script>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ahelp-website-server",
+  "version": "1.0.0",
+  "description": "Server for AHELP website authentication",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests\" && exit 0"
+  },
+  "dependencies": {
+    "body-parser": "^1.20.2",
+    "cookie-parser": "^1.4.6",
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const cookieParser = require('cookie-parser');
+
+const app = express();
+app.use(bodyParser.json());
+app.use(cookieParser());
+app.use(express.static('improved-website-v14'));
+
+// Simple in-memory user store
+const USERS = {
+  'user@example.com': { password: 'password', name: 'User' }
+};
+
+app.post('/api/login', (req, res) => {
+  const { email, password } = req.body;
+  const user = USERS[email];
+  if (user && user.password === password) {
+    const token = Math.random().toString(36).slice(2);
+    res.cookie('session', token, { httpOnly: true });
+    return res.json({ redirect: '/dashboard.html' });
+  }
+  res.status(401).json({ error: 'Invalid credentials' });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- Replace client-side login with fetch-based form submission to `/api/login` and rely on server response for navigation.
- Introduce Express server that validates credentials, issues an HTTP-only session cookie, and returns dashboard redirect.
- Add Node project configuration and ignore `node_modules`.

## Testing
- `npm install` *(failed: 403 Forbidden - GET https://registry.npmjs.org/body-parser)*
- `npm test`
- `node server.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_6893a8586f2c8320be7722a84dc5cb96