### PR TITLE
Fix Canva embed on home page

### DIFF
--- a/improved-website-v14/home.html
+++ b/improved-website-v14/home.html
@@ -54,16 +54,10 @@
     <p class="text-lg text-gray-700 dark-mode:text-gray-300 mb-4">AHELP (Arkansas Healthy Employee Lifestyle Program) is a state-sponsored initiative designed to encourage healthy habits, reduce healthcare costs, and improve the overall well-being of Arkansas state employees. The program provides tools, resources, and incentives to support physical, mental, and emotional wellness.</p>
     <p class="text-lg text-gray-700 dark-mode:text-gray-300">Participants track activities such as physical fitness, hydration, nutrition, and more — earning points toward tangible incentives like paid time off. It is accessible to all state employees and encourages cross-agency engagement through community challenges and progress tracking.</p>
   </section>
-  <div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%;
- padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden;
- border-radius: 8px; will-change: transform;">
-  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0; border: none; padding: 0;margin: 0;"
-    <!-- Video Section -->
+  <!-- Video Section -->
   <section class="px-6 max-w-4xl mx-auto">
     <div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%; padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden; border-radius: 8px; will-change: transform;">
-      <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0; border: none; padding: 0;margin: 0;"
-        src="https://www.canva.com/design/DAGuezM2ErU/q0i_wVejdzq0MIzJcSnOlw/watch?embed" allowfullscreen="allowfullscreen" allow="fullscreen">
-      </iframe>
+      <iframe loading="lazy" title="AHELP introduction video" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0; border: none; padding: 0;margin: 0;" src="https://www.canva.com/design/DAGuezM2ErU/q0i_wVejdzq0MIzJcSnOlw/watch?embed" allowfullscreen="allowfullscreen" allow="fullscreen"></iframe>
     </div>
     <div class="text-center text-sm text-gray-600 dark-mode:text-gray-400">
       <a href="https://www.canva.com/design/DAGuezM2ErU/q0i_wVejdzq0MIzJcSnOlw/watch?utm_content=DAGuezM2ErU&utm_campaign=designshare&utm_medium=embeds&utm_source=link" target="_blank" rel="noopener" class="underline">Copy of Welcome</a> by Shared Administrative Services


### PR DESCRIPTION
## Summary
- Clean up broken Canva embed in `home.html` by removing stray section/wrapper and ensuring iframe tag is properly closed
- Add descriptive title attribute and newline to Canva iframe for accessibility and clean markup

## Testing
- `npx html-validate improved-website-v14/home.html` *(fails: 403 Forbidden)*
- `python - <<'PY'
from html.parser import HTMLParser
class P(HTMLParser):
    def error(self, message):
        print('error', message)
parser = P()
with open('improved-website-v14/home.html') as f:
    parser.feed(f.read())
print('Parsing complete')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6893a8520d948320a09505d3e8949c1f