### PR TITLE
Remove challenge script from dashboard

### DIFF
--- a/improved-website-v14/dashboard.html
+++ b/improved-website-v14/dashboard.html
@@ -3097,5 +3097,5 @@
         document.getElementById('mobile-menu').classList.toggle('hidden');
     });
 </script>
-<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'9685e464f31dbd17',t:'MTc1NDA1NzE0NS4wMDAwMDA='};var a=document.createElement('script');a.nonce='';a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- Clean up dashboard HTML by deleting residual Cloudflare challenge script
- Ensure page ends cleanly with separate closing `</body>` and `</html>` tags

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893affbc81c8320920e73ffb9045618