### PR TITLE
chore: add package-lock for reproducible installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "ahelp-website",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ahelp-website",
+      "version": "1.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add npm-generated `package-lock.json` to ensure deterministic installs

## Testing
- `npm install`
- `npm start` *(fails: Missing script "start")*

------
https://chatgpt.com/codex/tasks/task_e_6893b01511ec83208c3ca5228e8b5c6d