### PR TITLE
Use secure session ids and document cookie settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# AHELP-Website-2
+# AHELP Website
+
+## Build
+
+Use `npm run build` to render HTML files from the `improved-website-v14` source directory into the `dist` folder.
+
+## Server
+
+`server.js` provides a tiny Node.js server.
+When a client posts to `/login` the server issues a session identifier using `crypto.randomUUID()`
+and returns it as an HTTP-only cookie.
+
+Cookie settings:
+
+- `HttpOnly` prevents client-side scripts from reading the cookie.
+- `SameSite=Strict` limits the cookie to same-site requests.
+- `Secure` is automatically added when `NODE_ENV` is set to `production`.
+
+### Configuration
+
+- `PORT` – port for the server to listen on (defaults to `3000`).
+- `NODE_ENV=production` – enable the `Secure` cookie attribute.
+
+Run the server with:
+
+```bash
+node server.js
+```

--- a/server.js
+++ b/server.js
@@ -1,0 +1,44 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const PORT = process.env.PORT || 3000;
+const secureFlag = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+const sameSite = 'Strict';
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/login' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      const sessionId = crypto.randomUUID();
+      const headers = {
+        'Content-Type': 'application/json',
+        'Set-Cookie': `session=${sessionId}; HttpOnly${secureFlag}; SameSite=${sameSite}; Path=/`
+      };
+      res.writeHead(200, headers);
+      res.end(JSON.stringify({ status: 'ok' }));
+    });
+  } else if (req.method === 'GET') {
+    const filePath = path.join(__dirname, 'improved-website-v14', req.url === '/' ? 'index.html' : req.url);
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not found');
+      } else {
+        res.writeHead(200);
+        res.end(data);
+      }
+    });
+  } else {
+    res.writeHead(405);
+    res.end();
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- replace Math.random token generation with crypto.randomUUID and set HTTP-only cookies with SameSite and optional Secure flag
- document server configuration and cookie attributes in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6893b01bb0d883209c8488f56ff966f9