### PR TITLE
Add basic auth backend and link login page

### DIFF
--- a/improved-website-v14/login.html
+++ b/improved-website-v14/login.html
@@ -67,7 +67,7 @@
                 <button id="signup-tab" class="flex-1 py-3 px-4 rounded-lg font-medium text-gray-600 hover:text-gray-900 transition-all">Sign Up</button>
             </div>
             <!-- Login Form -->
-            <form id="login-form" class="space-y-4">
+            <form id="login-form" class="space-y-4" method="post">
                 <div>
                     <label for="login-email" class="block text-sm font-medium text-gray-700 mb-1">Email</label>
                     <input id="login-email" type="email" required class="w-full px-4 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-purple-400 focus:border-transparent transition-all" placeholder="you@example.com">
@@ -81,7 +81,7 @@
                 </button>
             </form>
             <!-- Sign Up Form -->
-            <form id="signup-form" class="space-y-4 hidden">
+            <form id="signup-form" class="space-y-4 hidden" method="post">
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                         <label for="signup-first-name" class="block text-sm font-medium text-gray-700 mb-1">First Name</label>
@@ -159,26 +159,53 @@
         });
 
         // Handle login submission
-        loginForm.addEventListener('submit', (e) => {
+        loginForm.addEventListener('submit', async (e) => {
             e.preventDefault();
-            const emailInput = document.getElementById('login-email');
-            const emailVal = emailInput.value.trim();
-            let userName = 'User';
-            if (emailVal.includes('@')) {
-                userName = emailVal.split('@')[0];
+            const email = document.getElementById('login-email').value.trim();
+            const password = document.getElementById('login-password').value;
+            try {
+                const res = await fetch('/api/login', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ email, password })
+                });
+                if (res.ok) {
+                    const data = await res.json();
+                    localStorage.setItem('sessionToken', data.token);
+                    window.location.href = 'dashboard.html';
+                } else {
+                    alert('Login failed');
+                }
+            } catch (err) {
+                console.error(err);
+                alert('Login failed');
             }
-            localStorage.setItem('ahelpUserName', userName);
-            // Redirect to dashboard
-            window.location.href = 'dashboard.html';
         });
+
         // Handle sign up submission
-        signupForm.addEventListener('submit', (e) => {
+        signupForm.addEventListener('submit', async (e) => {
             e.preventDefault();
             const firstName = document.getElementById('signup-first-name').value.trim();
-            if (firstName) {
-                localStorage.setItem('ahelpUserName', firstName);
+            const lastName = document.getElementById('signup-last-name').value.trim();
+            const email = document.getElementById('signup-email').value.trim();
+            const password = document.getElementById('signup-password').value;
+            try {
+                const res = await fetch('/api/register', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ firstName, lastName, email, password })
+                });
+                if (res.ok) {
+                    const data = await res.json();
+                    localStorage.setItem('sessionToken', data.token);
+                    window.location.href = 'dashboard.html';
+                } else {
+                    alert('Registration failed');
+                }
+            } catch (err) {
+                console.error(err);
+                alert('Registration failed');
             }
-            window.location.href = 'dashboard.html';
         });
     </script>
     <!-- Back to Top Button -->

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "node build.js"
+    "build": "node build.js",
+    "start": "node server/index.js"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,99 @@
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const publicDir = path.join(__dirname, '..', 'improved-website-v14');
+
+const users = new Map(); // email -> { passwordHash, firstName, lastName }
+const sessions = new Map(); // token -> email
+
+function hash(password) {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+      if (body.length > 1e6) req.connection.destroy();
+    });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body || '{}');
+        resolve(data);
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'POST' && req.url === '/api/register') {
+    try {
+      const { firstName = '', lastName = '', email = '', password = '' } = await parseBody(req);
+      if (!email || !password) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'Email and password required' }));
+      }
+      if (users.has(email)) {
+        res.writeHead(409, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'User already exists' }));
+      }
+      users.set(email, { firstName, lastName, passwordHash: hash(password) });
+      const token = crypto.randomUUID();
+      sessions.set(token, email);
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Set-Cookie': `session=${token}; HttpOnly; Path=/; SameSite=Strict`
+      });
+      res.end(JSON.stringify({ token }));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Server error' }));
+    }
+  } else if (req.method === 'POST' && req.url === '/api/login') {
+    try {
+      const { email = '', password = '' } = await parseBody(req);
+      const user = users.get(email);
+      if (!user || user.passwordHash !== hash(password)) {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'Invalid credentials' }));
+      }
+      const token = crypto.randomUUID();
+      sessions.set(token, email);
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Set-Cookie': `session=${token}; HttpOnly; Path=/; SameSite=Strict`
+      });
+      res.end(JSON.stringify({ token }));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Server error' }));
+    }
+  } else if (req.method === 'GET') {
+    const safePath = req.url === '/' ? '/index.html' : req.url;
+    const filePath = path.join(publicDir, safePath);
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not found');
+      } else {
+        res.writeHead(200);
+        res.end(data);
+      }
+    });
+  } else {
+    res.writeHead(405).end();
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add minimal Node backend under `server/` for registering and logging in users with session tokens
- send login and signup forms to the backend via POST and store returned token
- add start script to run the backend server

## Testing
- `npm test` *(fails: Missing script "test")*
- `node server/index.js` *(server starts and is terminated after 1s)*

------
https://chatgpt.com/codex/tasks/task_e_6893b1f39cd4832090e6d5c8e2640ed8