### PR TITLE
refactor: use ES module syntax in build script

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,5 +1,8 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const inputDir = path.join(__dirname, 'improved-website-v14');
 const outputDir = path.join(__dirname, 'dist');


### PR DESCRIPTION
## Summary
- use ES module imports in build.js and compute __dirname via fileURLToPath

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893b6c0da4c8320b741cdfb3802dd24