### PR TITLE
Serve built assets and build on start

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "type": "module",
   "scripts": {
     "build": "node build.js",
-    "start": "node server/index.js"
+    "start": "npm run build && node server/index.js"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const publicDir = path.join(__dirname, '..', 'improved-website-v14');
+const publicDir = path.join(__dirname, '..', 'dist');
 
 const users = new Map(); // email -> { passwordHash, firstName, lastName }
 const sessions = new Map(); // token -> email


### PR DESCRIPTION
## Summary
- Serve compiled pages by setting the web server's `publicDir` to the `dist` folder.
- Run the build step automatically when starting the server.

## Testing
- `npm run build`
- `npm start`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893b8c44e548320bdb3660e17ba8759